### PR TITLE
add network name to header when wallet connected

### DIFF
--- a/packages/app/pages/index.tsx
+++ b/packages/app/pages/index.tsx
@@ -32,6 +32,8 @@ import axios from "axios";
 import UsersTabContent from "../components/UsersTabContent";
 import { ipfsAdd } from "../components/utils";
 
+import { getChainName } from "../utils/getChainName";
+
 const DRAWER_WIDTH = 255;
 const HEADER_HEIGHT = 64;
 
@@ -551,6 +553,7 @@ const HomeContent = () => {
   const tab = useMemo(() => router.asPath.replace(/^\/#?/, ""), [router]);
   const address = useAddress();
   const chainId = useChainId();
+  const chainName = getChainName(chainId);
   const connectWallet = useConnect();
   return (
     <div
@@ -577,7 +580,7 @@ const HomeContent = () => {
         {address ? (
           <>
             {chainId && (
-              <span style={{ marginRight: 16 }}>ChainId: {chainId}</span>
+              <span style={{ marginRight: 16 }}>Connected on {chainName}</span>
             )}
             <Button>
               {address.slice(0, 6)}...{address.slice(-4)}

--- a/packages/app/utils/getChainName.js
+++ b/packages/app/utils/getChainName.js
@@ -1,0 +1,38 @@
+export const getChainName = (chainId) => {
+    // non-local chains currently available from Metamask
+    const chains = [
+        {
+            chainId: 1,
+            chainName: "Ethereum mainnet"
+        },
+        {
+            chainId: 3,
+            chainName: "Ropsten testnet"
+        },
+        {
+            chainId: 4,
+            chainName: "Rinkeby testnet"
+        },
+        {
+            chainId: 5,
+            chainName: "Goerli testnet"
+        },
+        {
+            chainId: 42,
+            chainName: "Kovan testnet"
+        },
+    ];
+
+    let chainName;
+    for (let i = 0; i < chains.length; i++){
+        if (chains[i].chainId === chainId) {
+            chainName = chains[i].chainName
+        }
+    }
+
+    if (chainName) {
+        return chainName;
+    } else {
+        return "chain ID " + chainId;
+    }
+}


### PR DESCRIPTION
This is my first commit to this project and I'm not onboarded yet, so hopefully this isn't jumping the gun but...

A basic change to display the network name (instead of chain ID) in the header when a user connects their wallet/changes network. 

![image](https://user-images.githubusercontent.com/17968688/151698773-b2a69f29-0de5-4f62-8387-3b3389b4eb39.png)

This could be added to other sections of the app so that the user knows they are connected on the correct network.