### PR TITLE
Update readme to make it easier for new contributors to get started

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ If you are looking to make changes to the smart contracts, it helps to run a loc
 ### Wallet Setup
 
 1. Open up MetaMask, click the accounts circle in the top right and click "import account".
-1. Past the private key from step 3 and click import. (Each of the accounts created in step 3 are pre-populated with 10,000 ETH)
+1. Paste the private key from step 3 and click import. (Each of the accounts created in step 3 are pre-populated with 10,000 ETH)
 1. If you don't see the ETH balance after importing, switch off of the "Localhost" network you created to another network, then go back to "Localhost". You should then see the balance. 
 
 Note that every time you change the smart contracts, you will need to rebuild and redeploy it to your local network in order to see the changes. Most of the times this will copying the new contract address to your `packages/app/.env` file for you. You will then need to reboot the frontend.

--- a/README.md
+++ b/README.md
@@ -83,13 +83,19 @@ If you are looking to make changes to the smart contracts, it helps to run a loc
 1. Open another terminal tab and build the contracts with `npm run build`
 1. Deploy the newly build contracts to your local network with `npm run migrate:local`. Copy the address that the PassportFactory was deployed to.
 1. Navigate to the `packages/app` directory.
-1. A local `packages/app/.env` file should already be generated with the address you copied above. If not, create one and add `NEXT_PUBLIC_LOCAL_PASSPORT_FACTORY_ADDRESS=0x12341234` to the top of the file. Replace `0x12341234` with the address that you copied.
+1. Create another `.env` file at `packages/app.env`. Add `NEXT_PUBLIC_LOCAL_PASSPORT_FACTORY_ADDRESS=0x12341234` to the top of the file. Replace `0x12341234` with the address that you copied after step 3.
 1. Run the webapp locally by running `npm run dev` from the `packages/app` directory.
 1. Once on the browser, add the new network to your wallet. In Metamask, you could do this by going to Settings > Networks > Add Network and fill out the following data:
    - Network Name: Localhost
    - New RPC URL: http://localhost:8545
    - ChainId: 31337
-1. You can now connect to and interact with your local network
+1. You can now connect to and interact with your local network.
+
+### Wallet Setup
+
+1. Open up MetaMask, click the accounts circle in the top right and click "import account".
+1. Past the private key from step 3 and click import. (Each of the accounts created in step 3 are pre-populated with 10,000 ETH)
+1. If you don't see the ETH balance after importing, switch off of the "Localhost" network you created to another network, then go back to "Localhost". You should then see the balance. 
 
 Note that every time you change the smart contracts, you will need to rebuild and redeploy it to your local network in order to see the changes. Most of the times this will copying the new contract address to your `packages/app/.env` file for you. You will then need to reboot the frontend.
 


### PR DESCRIPTION
1. When I first ran `npm run migrate:local` it did not create a `.env` file. (Maybe someone should create a task to fix that instead of updating the  readme?)
2. It's not obvious what to do to get ETH in your wallet to start actually doing stuff.

