### PR TITLE
fix(checkout): Fix rendering loop if metadata doesn't change

### DIFF
--- a/packages/app/pages/checkout/[network]/[address].tsx
+++ b/packages/app/pages/checkout/[network]/[address].tsx
@@ -190,7 +190,9 @@ const CheckoutPageContent = ({
   useEffect(() => {
     if (!Object.entries(metadata).length && metadataHash) {
       axios.get(`https://ipfs.io/ipfs/${metadataHash}`).then((r) => {
-        setMetadata(r.data);
+        if (Object.entries(r.data)) {
+          setMetadata(r.data);
+        }
       });
     }
   }, [metadata, metadataHash]);


### PR DESCRIPTION
Setting state with the same value on nonprimitive data types will still cause a rerender. 